### PR TITLE
chore(deps): upgrade to clap v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,17 +26,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,24 +63,22 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "4.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
 dependencies = [
- "atty",
  "bitflags",
  "clap_lex",
- "indexmap",
+ "is-terminal",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -228,21 +215,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,16 +228,6 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "indexmap"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
 
 [[package]]
 name = "io-lifetimes"
@@ -283,7 +245,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "io-lifetimes",
  "rustix",
  "windows-sys 0.42.0",
@@ -547,12 +509,6 @@ name = "termtree"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "3.2.23"
+clap = "4.0.32"
 env_logger = "0.10.0"
 log = "0.4.17"
 rustyline = "10.0.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{Arg, ArgMatches, Command};
+use clap::{parser::ValueSource, Arg, ArgAction, ArgMatches, Command};
 use env_logger::{Builder, Env};
 use log::LevelFilter;
 use rawk::runtime_config::RuntimeConfig;
@@ -13,6 +13,9 @@ enum TempAwkReadFileError {
 
 const PROGRAM_KEY: &str = "program";
 const PROGRAM_FILE_KEY: &str = "file";
+const QUICK_KEY: &str = "quick";
+const EVAL_KEY: &str = "eval";
+const FIELD_SEPARATOR_KEY: &str = "field_separator";
 
 fn main() -> Result<(), Box<dyn Error>> {
     Builder::from_env(Env::default().default_filter_or("info"))
@@ -20,89 +23,80 @@ fn main() -> Result<(), Box<dyn Error>> {
         .filter_module("rustyline", LevelFilter::Error)
         .init();
 
-    const VERSION_KEY: &str = "version";
-    const QUICK_KEY: &str = "quick";
-    const EVAL_KEY: &str = "eval";
-    const FIELD_SEPARATOR_KEY: &str = "field_separator";
+    let cmd = build_awk_cli_command();
+    let render_version = cmd.render_version();
+    let cmd_line_matches = cmd.get_matches();
 
+    if !cmd_line_matches.contains_id(PROGRAM_KEY) && !cmd_line_matches.contains_id(PROGRAM_FILE_KEY)
+    {
+        // clap will add a newline to the rendered version string for us
+        print!("{render_version}");
+        return Ok(());
+    }
+
+    let field_separator = cmd_line_matches
+        .get_one::<String>(FIELD_SEPARATOR_KEY)
+        .map(|separator| separator.to_string())
+        .unwrap_or_else(|| panic!("{} not configured for command line", FIELD_SEPARATOR_KEY));
+
+    let is_eval = cmd_line_matches
+        .value_source(EVAL_KEY)
+        .unwrap_or_else(|| panic!("{} not configured for command line", EVAL_KEY))
+        .eq(&ValueSource::CommandLine);
+    let is_quick = cmd_line_matches
+        .value_source(QUICK_KEY)
+        .unwrap_or_else(|| panic!("{} not configured for command line", QUICK_KEY))
+        .eq(&ValueSource::CommandLine);
+    let config: RuntimeConfig = RuntimeConfig::new(None, field_separator, is_eval, is_quick);
+
+    let program = get_awk_program(&cmd_line_matches);
+    rawk::run_program(&program, config);
+    Ok(())
+}
+
+fn build_awk_cli_command() -> Command {
     // https://www.gnu.org/software/gawk/manual/html_node/Options.html
-    let cmd_line_app = Command::new(env!("CARGO_PKG_NAME"))
+    Command::new(env!("CARGO_PKG_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
-        .about("awk, implemented in Rust");
-
-    let version_info = cmd_line_app.render_version();
-
-    let cmd_line_matches = cmd_line_app
-        .arg(
-            Arg::new(VERSION_KEY)
-                .short('V')
-                .long(VERSION_KEY)
-                .takes_value(false)
-                .required(false)
-                .help("Determine the current version of r-awk"),
-        )
+        .about("awk, implemented in Rust")
         .arg(
             Arg::new(PROGRAM_FILE_KEY)
                 .short('f')
                 .long(PROGRAM_FILE_KEY)
-                .takes_value(true)
+                .num_args(1)
                 .required(false)
-                .multiple_occurrences(true)
-                .number_of_values(1)
+                .action(ArgAction::Append)
                 .help("Runs an awk program"),
         )
         .arg(
-            Arg::new(PROGRAM_KEY).index(1), // note this is the first positional argument, not the first argument as a whole
+            // note this is the first positional argument relative to other positional arguments.
+            // it is not the first position in the argument list as a whole
+            Arg::new(PROGRAM_KEY).index(1),
         )
         .arg(
             // TODO: Remove this when `BEGIN` is implemented. We could use -w, but this is quicker
             Arg::new(QUICK_KEY)
                 .short('q')
                 .long(QUICK_KEY)
-                .takes_value(false)
-                .required(false)
+                .action(ArgAction::SetTrue)
                 .help("Runs a single line of awk code without data, then terminates"),
         )
         .arg(
             Arg::new(EVAL_KEY)
                 .short('k') // '-e' is taken already...
                 .long(EVAL_KEY)
-                .takes_value(false)
-                .required(false)
+                .action(ArgAction::SetTrue)
                 .help("Runs a single line of awk code, then terminates"),
         )
         .arg(
             Arg::new(FIELD_SEPARATOR_KEY)
                 .short('F')
-                .takes_value(true)
+                .num_args(1)
                 .required(false)
+                .action(ArgAction::Set)
                 .default_value(" ")
                 .help("Sets the field separator character/regex for parsing data"),
         )
-        .get_matches();
-
-    if !cmd_line_matches.is_present(PROGRAM_KEY) && !cmd_line_matches.is_present(PROGRAM_FILE_KEY) {
-        // clap handles version flags itself, use post-matching results to handle other cases where
-        // we only wish to print the version info
-        println!("{}", version_info.trim());
-        return Ok(());
-    }
-
-    let program = get_awk_program(&cmd_line_matches);
-
-    let field_separator = cmd_line_matches
-        .value_of(FIELD_SEPARATOR_KEY)
-        .map(|separator| separator.to_string())
-        .expect("awk file separator default is unspecified");
-
-    let config: RuntimeConfig = RuntimeConfig::new(
-        None,
-        field_separator,
-        cmd_line_matches.is_present(EVAL_KEY),
-        cmd_line_matches.is_present(QUICK_KEY),
-    );
-    rawk::run_program(&program, config);
-    Ok(())
 }
 
 /// Retrieve an awk program from the command line
@@ -118,7 +112,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 /// # Return value
 /// - The awk program to run
 fn get_awk_program(cmd_line_matches: &ArgMatches) -> String {
-    if let Some(provided_awk_filepaths) = cmd_line_matches.values_of(PROGRAM_FILE_KEY) {
+    if let Some(provided_awk_filepaths) = cmd_line_matches.get_many::<String>(PROGRAM_FILE_KEY) {
         provided_awk_filepaths
             .map(|awk_filepath| {
                 // TODO: Support for '-' as a special filename
@@ -129,6 +123,19 @@ fn get_awk_program(cmd_line_matches: &ArgMatches) -> String {
             })
             .collect()
     } else {
-        cmd_line_matches.value_of(PROGRAM_KEY).unwrap().into()
+        cmd_line_matches
+            .get_one::<String>(PROGRAM_KEY)
+            .cloned()
+            .unwrap()
+    }
+}
+
+#[cfg(test)]
+mod cli {
+    use crate::build_awk_cli_command;
+
+    #[test]
+    fn verify_cli() {
+        build_awk_cli_command().debug_assert();
     }
 }


### PR DESCRIPTION
this commit pulls the generation of a clap `Command` entity to a
separate function, in an effort to test the command being generated as a
part of the v4 upgrade process, as outlined in
https://github.com/clap-rs/clap/releases/tag/v4.0.0-rc.1. doing so
allows us to use the `debug_assert()` function provided by clap in a new
unit test to help programmatically verify (some) of the cli's
configuration.

the various `*_KEY` str values were hoisted to the outermost scope of
the `main` entrypoint to allow for reuse. they were not refactored under
a single namespace (e.g. an `enum`) to keep the commit smaller and more
focused. this allows us to use the str's in multiple places throughout
the file.

the generation of `version` using the clap builder api has been removed,
as it is no longer needed (and in fact errors in at runtime should we
add it as-is without additional modifications to the `Command` entity).

in order to differentiate as to whether the `-q` (quick) and `-k` (eval)
flags have been set by the user or by clap, we can no longer check if
either key is present (as it will always be present). we can however,
determine if the user provided it using it's origin (the command line vs
a default field). the generation of a `RuntimeConfig` has been updated
accordingly to make thsi distinction.

any remaining changes not expressly called out were done in accordance
to the migration guide linked earlier in this commit msg