### PR TITLE
feat(data): accept data files when -f provided

### DIFF
--- a/tests/entrypoint.rs
+++ b/tests/entrypoint.rs
@@ -96,6 +96,48 @@ Erin 660"#,
     }
 
     #[test]
+    fn accepts_an_awk_and_data_input_file() {
+        utils::CodeRunner::init()
+            .cli_options(vec![
+                "-f",
+                "./awk_examples/field_variables/it_prints_all_line_parts.awk",
+                "./tests/data/hours1.dat",
+            ])
+            .expect_output(
+                r#"Alice 25.00 10
+Bob 20.75 20
+Charlie 15.25 40
+Dan 21.50 0
+Erin 22.00 30"#,
+            )
+            .assert()
+    }
+
+    #[test]
+    fn accepts_an_awk_and_data_input_files() {
+        utils::CodeRunner::init()
+            .cli_options(vec![
+                "-f",
+                "./awk_examples/field_variables/it_prints_all_line_parts.awk",
+                "./tests/data/hours1.dat",
+                "./tests/data/hours2.dat",
+            ])
+            .expect_output(
+                r#"Alice 25.00 10
+Bob 20.75 20
+Charlie 15.25 40
+Dan 21.50 0
+Erin 22.00 30
+Frank 15.00 11
+Gerry 1.75 19
+Hannah 25.50 40
+Igor 0 10
+Lauren 22.00 32"#,
+            )
+            .assert()
+    }
+
+    #[test]
     fn accepts_multiple_data_files() {
         utils::CodeRunner::init()
             .program("{print $1, $2 * $3;}")
@@ -180,5 +222,16 @@ Igor does not need to fill out a tax form
 Looking at employee Lauren
 Lauren needs to fill out a tax form"#)
             .assert();
+    }
+
+    #[test]
+    fn panics_when_awk_file_and_program_literal_are_provided() {
+        utils::CodeRunner::init()
+            .cli_options(vec![
+                "-f",
+                "./awk_examples/field_variables/it_prints_all_line_parts.awk",
+                "{print $0;}",
+            ])
+            .assert_fail();
     }
 }


### PR DESCRIPTION
this commit extends the work done in 4e053d0 by allowing rawk to accept data files to be read when the -f flag is present on the command line:
```bash
awk -f some_awk.awk some_data.dat
```

the problem that prevented this from being in the original featureset that this commit works around is that the first positional argument must be disambiguated. clap.rs has no idea whether the pos. arg is a file on dist or a program literal, e.g.
```
// legal awk program, first pos. arg is a data file
awk -f some_awk.awk some_data.dat
// illegal awk program, first pos. arg is a program literal
awk -f some_awk.awk '{print $0;}'
```

to work around this (either the limitation of clap or more likely, my lack of experience with it), if a first positional arg is provided in addition to -f with a value, place that first positional arg in the data_file_paths data structure, since its an illegal command.

this fix is a bit hacky - it assumes that this is the only logic for positional arguments that will occur. it is very possible this will need to be re-evaluated in the future as additional options are added.