### PR TITLE
test(print): add cases for printing default line

### DIFF
--- a/tests/entrypoint.rs
+++ b/tests/entrypoint.rs
@@ -96,6 +96,30 @@ Erin 660"#,
     }
 
     #[test]
+    fn prints_a_nothing_from_file_for_no_pattern_nor_action() {
+        utils::CodeRunner::init()
+            .program("")
+            .cli_options(vec!["./tests/data/hours1.dat"])
+            .expect_empty_output()
+            .assert();
+    }
+
+    #[test]
+    fn prints_a_data_file_for_no_action() {
+        utils::CodeRunner::init()
+            .program("1 > 0")
+            .cli_options(vec!["./tests/data/hours1.dat"])
+            .expect_output(
+                r#"Alice    25.00  10
+Bob      20.75  20
+Charlie  15.25  40
+Dan      21.50  0
+Erin     22.00  30"#,
+            )
+            .assert();
+    }
+
+    #[test]
     fn accepts_an_awk_and_data_input_file() {
         utils::CodeRunner::init()
             .cli_options(vec![


### PR DESCRIPTION
this commit adds two new test cases for the happy path of printing a line read in from a file:
1. no program (no action nor pattern) is provided
2. no action is provided

these have slight overlap with the pattern/action tests in the same directory, but focus on reading in a file from disk works as expected for printing the 0th field variable by default