### PR TITLE
feat(field_vars): print $0 if no expr provided

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -618,8 +618,15 @@ impl<'a> Parser<'a> {
     }
 
     fn print_expr_list_opt(&mut self) {
-        // TODO: Support empty
-        self.print_expr_list();
+        // TODO(FUTURE): when removing semicolon requirement, this will need to change to EoL and
+        // other keyword checks
+        if self.peek_token(&TokenType::Semicolon) {
+            // no expr - default to '$0'
+            self.emit_constant(Value::Number(0.0));
+            self.emit_byte(OpCode::GetFieldVariable());
+        } else {
+            self.print_expr_list();
+        }
     }
 
     fn print_expr_list(&mut self) {

--- a/tests/field_variables.rs
+++ b/tests/field_variables.rs
@@ -17,6 +17,15 @@ mod field_variables {
     }
 
     #[test]
+    fn it_prints_the_whole_line_empty_print_expr() {
+        utils::CodeRunner::init()
+            .program("{print;}")
+            .stdin_data("Alice 40 25")
+            .expect_output("Alice 40 25")
+            .assert()
+    }
+
+    #[test]
     fn it_prints_nothing_for_out_of_bounds() {
         // since we do _not_ print $0, whitespace is not preserved
         utils::CodeRunner::init()


### PR DESCRIPTION
this commit adds support for the case where an action with a print statement has a missing expression on the right hand side:
```awk
{ print; }
```

it does so by implicitly adding the 0th field variable (`$0`) to the right hand side, expanding the previous statement like so:
```diff
- { print; }
+ { print $0; }
```

at this time, we still assume that a statement will end with a semicolon, an assumption/bug that had existed in the implementation for quite some time. in the future, we must check for an EoL or non-expression (i.e. other keyword) to handle this more gracefully