### PR TITLE
chore(repo): remove actions-rs from actions runs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,10 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-          toolchain: 1.68.1
-          default: true
     - name: Build
       run: cargo build --verbose
     - name: Run tests
@@ -29,11 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.68.1
-          default: true
-          components: clippy
       - name: Run Clippy
         run: cargo clippy -- -D warnings
 
@@ -42,10 +33,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.68.1
-          default: true
-          components: rustfmt
       - name: Run rustfmt
         run: cargo fmt --all -- --check

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub fn run_program(program: &str, runtime_config: RuntimeConfig) {
     let scanner = Scanner::new(String::from(program));
     let tokens: Vec<Token> = scanner.scan();
 
-    if tokens.is_empty() || tokens.get(0).unwrap().token_type == &TokenType::Eof {
+    if tokens.is_empty() || tokens.first().unwrap().token_type == &TokenType::Eof {
         return;
     }
 


### PR DESCRIPTION
remove actions-rs from github actions runs for build_and_test, lint, and format jobs. actions-rs has been deprecated/unmaintained since it was archived of october 2023. while there are a few replacements that folks are gravitating to, for this project (with its small size and toy-ish nature), let's try running with the version of rust that gh action runners have by default (which is relatively recent-ish).