### PR TITLE
chore(repo): manage gh actions with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
add github actions to the list of ecosystems taht should be managed by github actions. this only adds the configuration to dependabot, it:
- doesn't upgrade anything
- pin dependencies to a specific sha

the former can happen via dependabot, whereas the latter is going to be a manual step. until i take care of that, this should be sufficient for us - we only use gh published actions here, so i'm slightly less concerned about security here.